### PR TITLE
Add get song by id with additional context

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -98,6 +98,12 @@
       <Compile Update="Endpoints\EventEndpoints\List.ListEventResponse.cs">
         <DependentUpon>List.cs</DependentUpon>
       </Compile>
+      <Compile Update="Endpoints\SongEndpoints\GetById.GetSongWithTopScoresResponse.cs">
+        <DependentUpon>GetById.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Endpoints\SongEndpoints\GetById.GetSongWithTopScoresRequest.cs">
+        <DependentUpon>GetById.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/Api/Endpoints/SongEndpoints/GetById.GetSongWithTopScoresRequest.cs
+++ b/Api/Endpoints/SongEndpoints/GetById.GetSongWithTopScoresRequest.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AusDdrApi.Endpoints.SongEndpoints;
+
+public class GetSongWithTopScoresRequest
+{
+    public const string Route = "/songs/{Id:guid}";
+    public static string BuildRoute(Guid id) => Route.Replace("{Id:guid}", id.ToString());
+        
+    [FromRoute]
+    public Guid Id { get; set; }
+}

--- a/Api/Endpoints/SongEndpoints/GetById.GetSongWithTopScoresResponse.cs
+++ b/Api/Endpoints/SongEndpoints/GetById.GetSongWithTopScoresResponse.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using Application.Core.Entities;
+
+namespace AusDdrApi.Endpoints.SongEndpoints;
+
+public record ScoreApiResponse(int Value, Guid DancerId);
+
+public record SongDifficultyApiResponse(Guid DifficultyId, PlayMode Mode, Difficulty Difficulty, int Level, IEnumerable<ScoreApiResponse> Scores);
+
+public record GetSongWithTopScoresResponse(Guid SongId, string Name, string Artist, IEnumerable<SongDifficultyApiResponse> SongDifficulties);

--- a/Api/Endpoints/SongEndpoints/GetById.cs
+++ b/Api/Endpoints/SongEndpoints/GetById.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Core.Entities;
+using Application.Core.Interfaces.Services;
+using AusDdrApi.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace AusDdrApi.Endpoints.SongEndpoints;
+
+public class GetById : EndpointWithResponse<GetSongWithTopScoresRequest, GetSongWithTopScoresResponse, Song>
+{
+    private readonly ISongService _songService;
+
+    public GetById(ISongService songService)
+    {
+        _songService = songService;
+    }
+
+    [HttpGet(GetSongWithTopScoresRequest.Route)]
+    [SwaggerOperation(
+        Summary = "Gets a Song with top 3 scores",
+        Description = "Gets a single Song with all associated difficulties and up to 3 scores",
+        OperationId = "Songs.GetById",
+        Tags = new[] { "Songs" })
+    ]
+    public override async Task<ActionResult<GetSongWithTopScoresResponse>> HandleAsync([FromRoute] GetSongWithTopScoresRequest request, CancellationToken cancellationToken = new CancellationToken())
+    {
+        var result = await _songService.GetSongWithTopScores(request.Id, cancellationToken);
+
+        return this.ConvertToActionResult(result);
+    }
+
+    public override GetSongWithTopScoresResponse Convert(Song u)
+    {
+        return new GetSongWithTopScoresResponse(u.Id, u.Name, u.Artist, GetSongDifficulties(u.SongDifficulties));
+    }
+
+    private IEnumerable<SongDifficultyApiResponse> GetSongDifficulties(IEnumerable<SongDifficulty>? difficulties)
+    {
+        if (difficulties == null) return new List<SongDifficultyApiResponse>();
+
+        return difficulties.Select(d =>
+        {
+            d.Scores ??= new List<Score>();
+            return new SongDifficultyApiResponse(d.Id, d.PlayMode, d.Difficulty, d.Level,
+                d.Scores.Select(s => new ScoreApiResponse(s.Value, s.DancerId)));
+        });
+    }
+}

--- a/Application.Core/Interfaces/Repositories/ISongRepository.cs
+++ b/Application.Core/Interfaces/Repositories/ISongRepository.cs
@@ -1,0 +1,10 @@
+using System;
+using Application.Core.Entities;
+using JetBrains.Annotations;
+
+namespace Application.Core.Interfaces.Repositories;
+
+public interface ISongRepository
+{
+    Song? GetSongWithTopScores(Guid songId);
+}

--- a/Application.Core/Interfaces/Services/ISongService.cs
+++ b/Application.Core/Interfaces/Services/ISongService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,5 +11,6 @@ namespace Application.Core.Interfaces.Services
     {
         Task<Result<IList<Song>>> GetSongsAsync(int page, int limit, CancellationToken cancellationToken);
         Task<Result<Song>> CreateSongAsync(Song song, CancellationToken cancellationToken);
+        Task<Result<Song>> GetSongWithTopScores(Guid songId, CancellationToken cancellationToken);
     }
 }

--- a/Application.Core/Services/SongService.cs
+++ b/Application.Core/Services/SongService.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Application.Core.Entities;
 using Application.Core.Interfaces;
+using Application.Core.Interfaces.Repositories;
 using Application.Core.Interfaces.Services;
 using Application.Core.Specifications.SongSpecs;
 using Ardalis.Result;
@@ -12,10 +14,12 @@ namespace Application.Core.Services
     public class SongService : CommonService<Song>, ISongService
     {
         private readonly IAsyncRepository<Song> _repository;
+        private readonly ISongRepository _songRepository;
 
-        public SongService(IAsyncRepository<Song> repository) : base(repository)
+        public SongService(IAsyncRepository<Song> repository, ISongRepository songRepository) : base(repository)
         {
             _repository = repository;
+            _songRepository = songRepository;
         }
         public async Task<Result<IList<Song>>> GetSongsAsync(int page, int limit, CancellationToken cancellationToken)
         {
@@ -29,6 +33,12 @@ namespace Application.Core.Services
         {
             var created = await _repository.AddAsync(song, cancellationToken);
             return Result<Song>.Success(created);
+        }
+
+        public async Task<Result<Song>> GetSongWithTopScores(Guid songId, CancellationToken cancellationToken)
+        {
+            var result = _songRepository.GetSongWithTopScores(songId);
+            return result == null ? Result<Song>.NotFound() : Result<Song>.Success(result);
         }
     }
 }

--- a/Infrastructure/Data/SongRepository.cs
+++ b/Infrastructure/Data/SongRepository.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Application.Core.Entities;
+using Application.Core.Interfaces.Repositories;
+using JetBrains.Annotations;
+
+namespace Infrastructure.Data;
+
+public class SongRepository : ISongRepository
+{
+    private readonly EFDatabaseContext _context;
+    
+    public SongRepository(EFDatabaseContext context)
+    {
+        _context = context;
+    }
+
+    public Song GetSongWithTopScores(Guid songId)
+    {
+        return _context
+            .Songs
+            .Where(s => s.Id.Equals(songId))
+            .Select(s => new Song
+            {
+                Id = s.Id,
+                Name = s.Name,
+                Artist = s.Artist,
+                SongDifficulties = s.SongDifficulties.Select(sd => new SongDifficulty
+                {
+                    Id = sd.Id,
+                    Difficulty = sd.Difficulty,
+                    Level = sd.Level,
+                    PlayMode = sd.PlayMode,
+                    Scores = sd.Scores.OrderByDescending(score => score.Value).Take(3).ToArray()
+                }).ToList()
+            }).FirstOrDefault();
+    }
+}

--- a/Infrastructure/DefaultInfrastructureModule.cs
+++ b/Infrastructure/DefaultInfrastructureModule.cs
@@ -3,6 +3,7 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Application.Core.Interfaces;
+using Application.Core.Interfaces.Repositories;
 using AusDdrApi.Context;
 using AusDdrApi.Services.FileStorage;
 using Infrastructure.Cache;
@@ -22,6 +23,7 @@ namespace Infrastructure
                 .AddSingleton<ICache, InMemoryCache>()
                 .AddIdentity(configuration)
                 .AddScoped(typeof(IAsyncRepository<>), typeof(GenericEfRepository<>))
+                .AddScoped<ISongRepository, SongRepository>()
                 .AddFileStorage(configuration);
         }
 

--- a/tests/IntegrationTests/Core/Services/SongServiceTests.cs
+++ b/tests/IntegrationTests/Core/Services/SongServiceTests.cs
@@ -24,7 +24,7 @@ namespace IntegrationTests.Core.Services
             _fixture = fixture;
 
             _songRepository = new GenericEfRepository<Song>(_fixture._context);
-            _songService = new SongService(_songRepository);
+            _songService = new SongService(_songRepository, new SongRepository(_fixture._context));
             
             Setup.DropAllRows(_fixture._context);
         }

--- a/tests/IntegrationTests/Infrastructure/Data/SongRepositoryTests.cs
+++ b/tests/IntegrationTests/Infrastructure/Data/SongRepositoryTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Application.Core.Entities;
+using Infrastructure.Data;
+using Xunit;
+
+namespace IntegrationTests.Infrastructure.Data;
+
+[Collection("Postgres database collection")]
+public class SongRepositoryTests
+{
+    private readonly PostgresDatabaseFixture _fixture;
+    private readonly SongRepository _songRepository;
+
+    public SongRepositoryTests(PostgresDatabaseFixture fixture)
+    {
+        _fixture = fixture;
+        _songRepository = new SongRepository(_fixture._context);
+        Setup.DropAllRows(_fixture._context);
+    }
+
+    #region GetSongWithTopScores
+
+    [Fact(DisplayName = "When song has no difficulties, return just song")]
+    public void WhenSongHasNoDifficulties_ReturnSong()
+    {
+        var song = new Song
+        {
+            Name = "sample-name"
+        };
+
+        var addedSong = _fixture._context.Songs.Add(song);
+        _fixture._context.SaveChanges();
+
+        var result = _songRepository.GetSongWithTopScores(addedSong.Entity.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(song.Name, result.Name);
+    }
+
+    [Fact(DisplayName = "When song has difficulties with no scores, return difficulties")]
+    public void WhenSongHasDifficulties_ReturnWithDifficulties()
+    {
+        var song = new Song
+        {
+            Name = "sample-name",
+            SongDifficulties = new List<SongDifficulty>()
+            {
+                new SongDifficulty()
+                {
+                    Difficulty = Difficulty.BASIC
+                },
+                new SongDifficulty()
+                {
+                    Difficulty = Difficulty.CHALLENGE
+                }
+            }
+        };
+
+        var addedSong = _fixture._context.Songs.Add(song);
+        _fixture._context.SaveChanges();
+
+        var result = _songRepository.GetSongWithTopScores(addedSong.Entity.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(song.Name, result.Name);
+        Assert.Equal(2, result.SongDifficulties.Count);
+    }
+
+    [Fact(DisplayName = "When song has difficulties with scores, top 3 scores are returned")]
+    public void WhenSongHasDifficultiesWithScores_ThenProvideTop3Scores()
+    {
+        var dancer = new Dancer();
+        dancer = _fixture._context.Dancers.Add(dancer).Entity;
+        var songDifficulty1 = new SongDifficulty()
+        {
+            Difficulty = Difficulty.BASIC,
+            Scores = Enumerable.Range(0, 10).Select(num => new Score() {Value = num, DancerId = dancer.Id}).ToList()
+        };
+        var songDifficulty2 = new SongDifficulty()
+        {
+            Difficulty = Difficulty.CHALLENGE,
+            Scores = Enumerable.Range(0, 2).Select(num => new Score() {Value = num, DancerId = dancer.Id}).ToList()
+        };
+        var song = new Song()
+        {
+            Name = "sample-name",
+            SongDifficulties = new List<SongDifficulty>() {songDifficulty1, songDifficulty2}
+        };
+
+        var addedSong = _fixture._context.Songs.Add(song);
+        _fixture._context.SaveChanges();
+
+        var result = _songRepository.GetSongWithTopScores(addedSong.Entity.Id);
+        
+        Assert.NotNull(result);
+        Assert.Equal(song.Name, result.Name);
+        Assert.Equal(2, result.SongDifficulties.Count);
+        
+        Assert.Equal(3, result.SongDifficulties.First(d => d.Difficulty.Equals(Difficulty.BASIC)).Scores.Count);
+        Assert.Equal(2, result.SongDifficulties.First(d => d.Difficulty.Equals(Difficulty.CHALLENGE)).Scores.Count);
+    }
+
+    [Fact(DisplayName = "When song not found, return null")]
+    public void WhenSongNotFound_ReturnNull()
+    {
+        var result = _songRepository.GetSongWithTopScores(Guid.NewGuid());
+        Assert.Null(result);
+    }
+
+    #endregion
+}

--- a/tests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/IntegrationTests/IntegrationTests.csproj
@@ -24,8 +24,4 @@
         <ProjectReference Include="..\..\Infrastructure\Infrastructure.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Infrastructure" />
-    </ItemGroup>
-
 </Project>

--- a/tests/UnitTests/Core/Services/BadgeServiceTests.cs
+++ b/tests/UnitTests/Core/Services/BadgeServiceTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Core.Entities;
+using Application.Core.Interfaces;
+using Application.Core.Interfaces.Services;
+using Application.Core.Services;
+using Application.Core.Specifications;
+using Moq;
+using Xunit;
+
+namespace UnitTests.Core.Services;
+
+public class BadgeServiceTests
+{
+    private readonly Mock<IAsyncRepository<Badge>> _badgeRepository;
+    private readonly IBadgeService _badgeService;
+
+    public BadgeServiceTests()
+    {
+        _badgeRepository = new Mock<IAsyncRepository<Badge>>();
+        _badgeService = new BadgeService(_badgeRepository.Object);
+    }
+
+    #region GetBadgesAsync
+
+    [Fact(DisplayName = "When GetBadgesAsync, repository is called with paging spec")]
+    public async Task When_GetBadgesAsync_Then_PagedRequestToRepository()
+    {
+        _badgeRepository.Setup(r =>
+            r.ListAsync(
+                It.IsAny<PageableSpec<Badge>>(), 
+                It.IsAny<CancellationToken>())
+            ).ReturnsAsync(new List<Badge>());
+
+        var result = await _badgeService.GetBadgesAsync(2, 10, CancellationToken.None);
+        
+        // TODO: validate spec with paging details
+        
+        Assert.True(result.IsSuccess);
+    }
+
+    #endregion
+
+    #region CreateBadgeAsync
+
+    [Fact(DisplayName = "When CreateBadgeAsync, repository is called with new badge")]
+    public async Task When_CreateBadgeAsync_Then_RepositoryIsCalledWithBadge()
+    {
+        var badge = new Badge
+        {
+            Id = Guid.NewGuid()
+        };
+
+        _badgeRepository.Setup(r => 
+            r.AddAsync(It.IsAny<Badge>(), It.IsAny<CancellationToken>())
+            ).ReturnsAsync(badge);
+
+        var result = await _badgeService.CreateBadgeAsync(badge, CancellationToken.None);
+        
+        _badgeRepository.Verify(r =>
+            r.AddAsync(badge, It.IsAny<CancellationToken>()));
+        
+        Assert.True(result.IsSuccess);
+        Assert.Equal(badge, result.Value);
+    }
+
+    #endregion
+}

--- a/tests/UnitTests/Core/Services/SongServiceTests.cs
+++ b/tests/UnitTests/Core/Services/SongServiceTests.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Application.Core.Entities;
 using Application.Core.Services;
+using Infrastructure.Data;
+using Moq;
 using Xunit;
 
 namespace UnitTests.Core.Services
@@ -18,7 +20,8 @@ namespace UnitTests.Core.Services
         public async Task GetSongsAsync_ReturnSongsWithDifficulties()
         {
             var repository = InMemoryDatabaseRepository<Song>.CreateRepository();
-            var service = new SongService(repository);
+            var songRepository = new Mock<SongRepository>();
+            var service = new SongService(repository, songRepository.Object);
             var song1 = new Song
             {
                 Id = Guid.NewGuid(),
@@ -62,7 +65,8 @@ namespace UnitTests.Core.Services
         public async Task GetSongsAsync_OnlyTakeSongsWithinPageSize()
         {
             var repository = InMemoryDatabaseRepository<Song>.CreateRepository();
-            var service = new SongService(repository);
+            var songRepository = new Mock<SongRepository>();
+            var service = new SongService(repository, songRepository.Object);
             var songs = new List<Song>
             {
                 new()


### PR DESCRIPTION
This is an attempt at an endpoint that will:
Get a song by ID
- With all associated difficulties
- With up to the top 3 scores for _each_ difficulty

This is intended to be used for a page for a given song, although mostly done as an experiment. Response payload looks like the following:

```
{
   "songId":"4bd89e3b-f760-4161-805e-18e14933dd90",
   "name":"My song",
   "artist":"My artist",
   "songDifficulties":[
      {
         "difficultyId":"89440754-514b-4aae-a422-0674e075530d",
         "mode":1,
         "difficulty":2,
         "level":11,
         "scores":[
            {
               "value":88,
               "dancerId":"8809fa6e-05ab-48bc-bc63-fbc651322bd8"
            },
            {
               "value":34,
               "dancerId":"8809fa6e-05ab-48bc-bc63-fbc651322bd8"
            },
            {
               "value":22,
               "dancerId":"8809fa6e-05ab-48bc-bc63-fbc651322bd8"
            }
         ]
      }
   ]
}
```